### PR TITLE
fix wrong m_renderCount value after calling CKLBNode::setRenderSlotCount(1)

### DIFF
--- a/Engine/source/SceneGraph/CKLBNode.cpp
+++ b/Engine/source/SceneGraph/CKLBNode.cpp
@@ -453,6 +453,7 @@ bool CKLBNode::setRenderSlotCount	(u32 slot) {
 
 	if (slot == 1) {
 		m_pRender		= &m_renderSlot;
+		m_renderCount = 1;
 	}
 
 	return res;


### PR DESCRIPTION
 fix wrong m_renderCount value after calling CKLBNode::setRenderSlotCount(1)

CKLBNode *node = ...;
node->setRenderSlotCount(2);
node->setRenderSlotCount(1);
// expected: m_renderCount == 1
// actual: m_renderCount == 0
