### PR TITLE
Visual Studioでビルドエラーが発生するのでtypedefを追加

### DIFF
--- a/Engine/source/Core/DebugTracker.cpp
+++ b/Engine/source/Core/DebugTracker.cpp
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #else
 #include <Windows.h>
+typedef unsigned __int32 uint32_t;
 #endif
 
 #include "BaseType.h"


### PR DESCRIPTION
ちょっとググったらVisual Studio 2010以降のは、C99の完全なサポートは行われてない感じなので
とりあえずの対応案
